### PR TITLE
feat(auth): basic sign in with two providers

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
     import "../app.css";
-    import { auth } from '$lib/firebase';
-    import { browser } from "$app/environment";
-
-    let isLoggedIn = auth && auth.currentUser;
 </script>
 
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,12 @@
+<script lang="ts">
+    import { user, signOut } from '$lib/firebase';
+    console.log($user);
+</script>
+
 <h1>Blend: The Orton-Gillingham method made easy</h1>
-<p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
+{#if $user}
+    <p>Welcome back, {$user.displayName}</p>
+    <button style="max-width: 100px;" on:click={signOut}>Sign out</button>
+{:else}
+    <p>Welcome, new user! Make an account or log in <a href="/login">here</a></p>
+{/if}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+    import { auth, signInWithGoogle, signInWithFacebook } from "$lib/firebase";
+</script>
+
+<h1>Log in or Create Account</h1>
+
+<h2>Please choose one of the following providers:</h2>
+<button on:click={signInWithGoogle}>Google</button>
+<button on:click={signInWithFacebook}>Facebook</button>
+
+<style>
+    button {
+        max-width: 100px;
+    }
+</style>


### PR DESCRIPTION
Supports Facebook and Google sign-in. Will add more later. Right now, it will only let users sign in to one provider (with exceptions, will explain later). So if you first signed in with Google, you can't sign in with Facebook later, but for now an error will come up saying "You need to sign in with Google". 

In the future we can implement account linking, but it takes a little more work than I want to do right now. That will enable users to use multiple providers for the same account. 

For database purposes, you can use the user UUID from Firebase to index their data. When we link providers in the future, the account will share a UUID no matter where they log in from. 