### PR TITLE
hotfix(svelte-kit-upgrade): upgrade sveltekit to 1.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"@playwright/test": "^1.28.1",
 				"@sveltejs/adapter-auto": "^2.0.0",
 				"@sveltejs/adapter-netlify": "^2.0.5",
-				"@sveltejs/kit": "^1.5.0",
+				"@sveltejs/kit": "^1.15.1",
 				"@typescript-eslint/eslint-plugin": "^5.45.0",
 				"@typescript-eslint/parser": "^5.45.0",
 				"eslint": "^8.28.0",
@@ -1414,9 +1414,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.13.0.tgz",
-			"integrity": "sha512-t44xqlSTn/k+BridiJFTD8dCRPNd9msCSSPLZT+/3P9deNp/al6ed396MSpsskK7r2kevYmmxywK16qtn6Rvjw==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.1.tgz",
+			"integrity": "sha512-Wexy3N+COoClTuRawVJRbLoH5HFxNrXG3uoHt/Yd5IGx8WAcJM9Nj/CcBLw/tjCR9uDDYMnx27HxuPy3YIYQUA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -1432,7 +1432,7 @@
 				"set-cookie-parser": "^2.5.1",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.21.0"
+				"undici": "5.20.0"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -5719,9 +5719,9 @@
 			"optional": true
 		},
 		"node_modules/undici": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
-			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
 			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
@@ -7478,9 +7478,9 @@
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.13.0.tgz",
-			"integrity": "sha512-t44xqlSTn/k+BridiJFTD8dCRPNd9msCSSPLZT+/3P9deNp/al6ed396MSpsskK7r2kevYmmxywK16qtn6Rvjw==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.1.tgz",
+			"integrity": "sha512-Wexy3N+COoClTuRawVJRbLoH5HFxNrXG3uoHt/Yd5IGx8WAcJM9Nj/CcBLw/tjCR9uDDYMnx27HxuPy3YIYQUA==",
 			"dev": true,
 			"requires": {
 				"@sveltejs/vite-plugin-svelte": "^2.0.0",
@@ -7495,7 +7495,7 @@
 				"set-cookie-parser": "^2.5.1",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.21.0"
+				"undici": "5.20.0"
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
@@ -10705,9 +10705,9 @@
 			"optional": true
 		},
 		"undici": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
-			"integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
 			"dev": true,
 			"requires": {
 				"busboy": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@playwright/test": "^1.28.1",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/adapter-netlify": "^2.0.5",
-		"@sveltejs/kit": "^1.5.0",
+		"@sveltejs/kit": "^1.15.1",
 		"@typescript-eslint/eslint-plugin": "^5.45.0",
 		"@typescript-eslint/parser": "^5.45.0",
 		"eslint": "^8.28.0",


### PR DESCRIPTION
upgraded sveltekit version due to a vulnerability in v < 1.15.1