### PR TITLE
feat(limit-one-free-trial): check if customer had sub before, then sub

### DIFF
--- a/src/lib/server/subscriptionUtils.ts
+++ b/src/lib/server/subscriptionUtils.ts
@@ -27,9 +27,24 @@ export const getStripeCustomerWithSubscriptions = async (uid: string) => {
         expand: ['subscriptions']
     });
 }
+
+export const getAllCustomerSubscriptions = async (uid: string) => {
+    const stripeCustomerId: string | null = (await db.ref(`/users/${uid}/private/stripeCustomerId`).once('value')).val();
+    if (stripeCustomerId === null)
+        return stripeCustomerId;
+    return await stripe.subscriptions.list({
+        customer: stripeCustomerId,
+        expand: ['data.items'],
+        status: 'all'
+    });
+}
+
 export const getBlendProSubscription = (customer: Stripe.Customer) => customer.subscriptions?.data.find((subscription) => subscription.items.data.find(({plan: { product, active }}) => active && product === STRIPE_BLEND_PRO_PRODUCT_CODE));
 
 export const getCustomerPortalSession = (customer: Stripe.Customer, returnUrl: string) => stripe.billingPortal.sessions.create({
     customer: customer.id,
     return_url: returnUrl
-})
+});
+
+export const hasCustomerSubscribedBefore = (subscriptions: Stripe.Response<Stripe.ApiList<Stripe.Subscription>>, productCode: string) =>
+  subscriptions.data.some((subscription) => subscription.items.data.some((item) => item.price.product === productCode));

--- a/src/lib/server/subscriptionUtils.ts
+++ b/src/lib/server/subscriptionUtils.ts
@@ -31,12 +31,13 @@ export const getStripeCustomerWithSubscriptions = async (uid: string) => {
 export const getAllCustomerSubscriptions = async (uid: string) => {
     const stripeCustomerId: string | null = (await db.ref(`/users/${uid}/private/stripeCustomerId`).once('value')).val();
     if (stripeCustomerId === null)
-        return stripeCustomerId;
-    return await stripe.subscriptions.list({
+        return [];
+    const subscriptions = await stripe.subscriptions.list({
         customer: stripeCustomerId,
         expand: ['data.items'],
         status: 'all'
     });
+    return subscriptions.data;
 }
 
 export const getBlendProSubscription = (customer: Stripe.Customer) => customer.subscriptions?.data.find((subscription) => subscription.items.data.find(({plan: { product, active }}) => active && product === STRIPE_BLEND_PRO_PRODUCT_CODE));
@@ -46,5 +47,5 @@ export const getCustomerPortalSession = (customer: Stripe.Customer, returnUrl: s
     return_url: returnUrl
 });
 
-export const hasCustomerSubscribedBefore = (subscriptions: Stripe.Response<Stripe.ApiList<Stripe.Subscription>>, productCode: string) =>
-  subscriptions.data.some((subscription) => subscription.items.data.some((item) => item.price.product === productCode));
+export const hasCustomerSubscribedBefore = (subscriptions: Stripe.Subscription[], productCode: string) =>
+  subscriptions.some((subscription) => subscription.items.data.some((item) => item.price.product === productCode));

--- a/src/routes/account/[uid]/+page.server.ts
+++ b/src/routes/account/[uid]/+page.server.ts
@@ -46,7 +46,9 @@ export const actions = {
                 console.error(`User ${uid} is already subscribed to Blend Pro, aborting`);
                 throw error(400, "Customer is already subscribed to Blend Pro!");
             }
-            subscriptionData = !hasCustomerSubscribedBefore(allSubscriptions, PRODUCT_CODE) ? {trial_period_days: 30} : {};
+            if (!hasCustomerSubscribedBefore(allSubscriptions, PRODUCT_CODE)) {
+              subscriptionData = {trial_period_days: 30};
+            }
             console.log(`Customer is ${subscriptionData.trial_period_days ? '' : 'not '}eligible for a free trial.`)
         }
         console.log("Creating Stripe session");

--- a/src/routes/account/[uid]/+page.server.ts
+++ b/src/routes/account/[uid]/+page.server.ts
@@ -31,7 +31,7 @@ export const actions = {
             getAllCustomerSubscriptions(uid),
         ]);
 
-        let subscriptionData;
+        let subscriptionData = {};
         if (!customer || customer.deleted) {
             console.log(`No Stripe customer exists for user ${uid}, creating one`);
             customer = await stripeClient.customers.create({

--- a/src/routes/account/[uid]/+page.server.ts
+++ b/src/routes/account/[uid]/+page.server.ts
@@ -31,6 +31,7 @@ export const actions = {
             getAllCustomerSubscriptions(uid),
         ]);
 
+        let subscriptionData;
         if (!customer || customer.deleted) {
             console.log(`No Stripe customer exists for user ${uid}, creating one`);
             customer = await stripeClient.customers.create({
@@ -45,11 +46,10 @@ export const actions = {
                 console.error(`User ${uid} is already subscribed to Blend Pro, aborting`);
                 throw error(400, "Customer is already subscribed to Blend Pro!");
             }
+            subscriptionData = !hasCustomerSubscribedBefore(allSubscriptions, PRODUCT_CODE) ? {trial_period_days: 30} : {};
+            console.log(`Customer is ${subscriptionData.trial_period_days ? '' : 'not '}eligible for a free trial.`)
         }
         console.log("Creating Stripe session");
-
-        const subscriptionData = !allSubscriptions || !hasCustomerSubscribedBefore(allSubscriptions, PRODUCT_CODE) ? {trial_period_days: 30} : {};
-        console.log(`Customer is ${subscriptionData.trial_period_days ? '' : 'not '}eligible for a free trial.`)
         
         const session = await stripeClient.checkout.sessions.create({
             customer: customer.id,

--- a/src/routes/account/[uid]/+page.server.ts
+++ b/src/routes/account/[uid]/+page.server.ts
@@ -1,9 +1,10 @@
 import type { Actions, PageServerLoad } from "./$types";
 import { error, redirect } from "@sveltejs/kit";
-import { stripeClient, firebaseDb, getStripeCustomerWithSubscriptions, getBlendProSubscription, PRICE_CODE, getCustomerPortalSession } from "$lib/server/subscriptionUtils";
+import { stripeClient, firebaseDb, getStripeCustomerWithSubscriptions, getBlendProSubscription, getAllCustomerSubscriptions, hasCustomerSubscribedBefore, getCustomerPortalSession, PRICE_CODE, PRODUCT_CODE } from "$lib/server/subscriptionUtils";
 
 export const load = (async ({ params: { uid } }) => {
     const customer = await getStripeCustomerWithSubscriptions(uid);
+
     if (!customer || customer.deleted) {
         return {
             isSubscribedToBlendPro: false,
@@ -24,7 +25,12 @@ export const actions = {
         const data = await request.formData();
         console.log(`Fetching Stripe customer ID for user ${uid}`);
         const stripeCustomerIdRef = firebaseDb.ref(`/users/${uid}/private/stripeCustomerId`);
-        let customer = await getStripeCustomerWithSubscriptions(uid);
+        
+        let [customer, allSubscriptions] = await Promise.all([
+            getStripeCustomerWithSubscriptions(uid),
+            getAllCustomerSubscriptions(uid),
+        ]);
+
         if (!customer || customer.deleted) {
             console.log(`No Stripe customer exists for user ${uid}, creating one`);
             customer = await stripeClient.customers.create({
@@ -41,6 +47,10 @@ export const actions = {
             }
         }
         console.log("Creating Stripe session");
+
+        const subscriptionData = !allSubscriptions || !hasCustomerSubscribedBefore(allSubscriptions, PRODUCT_CODE) ? {trial_period_days: 30} : {};
+        console.log(`Customer is ${subscriptionData.trial_period_days ? '' : 'not '}eligible for a free trial.`)
+        
         const session = await stripeClient.checkout.sessions.create({
             customer: customer.id,
             billing_address_collection: 'auto',
@@ -50,9 +60,7 @@ export const actions = {
                     quantity: 1,
                 },
             ],
-            subscription_data: {
-                trial_period_days: 30,
-            },
+            subscription_data: subscriptionData,
             mode: 'subscription',
             success_url: `${origin}/account/${uid}?subscription_checkout_status=success?session_id={CHECKOUT_SESSION_ID}`,
             cancel_url: `${origin}/account/${uid}?subscription_checkout_status=cancel`,

--- a/src/routes/account/[uid]/+page.svelte
+++ b/src/routes/account/[uid]/+page.svelte
@@ -106,7 +106,7 @@
         <form action="?/createSubscriptionOrder" method="POST">
           <input type="hidden" name="email" value={$user?.email} />
           <input type="hidden" name="name" value={$user?.displayName} />
-          <button id="checkout-and-portal-button" type="submit" class="btn">Subscribe</button>
+          <button id="checkout-and-portal-button" type="submit" class="btn">Upgrade to Blend Pro</button>
         </form>
       {/if}
     </div>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -42,7 +42,7 @@ h6 {
   border: 1px solid #FFFFFF;
   border-radius: 8px;
   height: 2.7rem;
-  width: 13rem;
+  min-width: 13rem;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
Changes: 

- added function to check if a customer has ever had a subscription to Blend Pro before -- evidently the list of subscriptions in `getCustomerWithSubscriptions` only shows active ones, hence making the new function. Not sure if I missed something with the existing function you had though so if it can be consolidated, please let me know! I couldn't figure out a way to in the version of the API we're using.
- If a customer has ever had a subscription to Blend Pro, they're not eligible for a free trial so we just don't pass anything in the `subscription_data` object and it will not create a trial period at all. Otherwise, if they're a new subscriber, leave the trial period data and it will start their trial
- also changed the verbiage on the account page from `Subscribe` to `Upgrade to Blend Pro` to be consistent with the rest of our language on marketing and the app