### PR TITLE
feat(organization-playlists): add support for organization playlists

### DIFF
--- a/firebase-local/mockData/database_export/csma-blend-default-rtdb.json
+++ b/firebase-local/mockData/database_export/csma-blend-default-rtdb.json
@@ -798,6 +798,6 @@
   },
   "users": {
     "Gcr9kCdvK617pSvK8Vn0uXWSjT0Z": { "private": { "stripeCustomerId": "cus_OSMO1QvLtZ2686" }, "protected": { "organizations": ["0000"] } },
-    "TpyNkRxiWfPwunyYEO9fIXlQ26bc": { "private": { "stripeCustomerId": "jnfsdkjnfsdjlk" }, "protected": { "organizations": ["0000"] } }
+    "TpyNkRxiWfPwunyYEO9fIXlQ26bc": { "protected": { "organizations": ["0000"] } }
   }
 }

--- a/firebase-local/rtdb.rules.json
+++ b/firebase-local/rtdb.rules.json
@@ -30,6 +30,12 @@
           ".read": "$uid === auth.uid",
           ".write": "$uid === auth.uid"
         }
+      },
+      "organization": {
+        "$orgId": {
+          ".read": "root.child('organizations').child($orgId).child('private').child('members').child(auth.uid).exists()",
+          ".write": "root.child('organizations').child($orgId).child('private').child('members').child(auth.uid).child('role').val() == 'admin'"
+        }
       }
     },
     "organizations": {

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -69,6 +69,25 @@ declare global {
         [deckId: string]: Deck;
       }
     }
+    interface Playlist {
+      created_ts: string;
+      modified_ts: string;
+      is_editable: boolean;
+      name: string;
+      position: number;
+      refId: number;
+    }
+    namespace Playlists {
+      interface Organization {
+        [playlistId: string]: {
+          author?: string;
+          playlist: Playlist;
+        };
+      }
+      interface User {
+        [playlistId: string]: Playlist;
+      }
+    }
     namespace Invite {
       interface Organization {
         orgId: string;

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -76,6 +76,7 @@ declare global {
       name: string;
       position: number;
       refId: number;
+      words: [][];
     }
     namespace Playlists {
       interface Organization {

--- a/src/lib/server/firebaseUtils.ts
+++ b/src/lib/server/firebaseUtils.ts
@@ -57,6 +57,7 @@ export const getUserOrganizations = async (uid: string) => {
   ).filter((id): id is Exclude<string, null> => !!id);
 };
 
+export const getOrganizationInfo = async (organizationId: string) => readPath<Database.Organization.Public>(`organizations/${organizationId}/public`);
 export const getOrganizationDecks = async (organizationId: string) => readPath<Database.Decks.Organization>(`decks/organization/${organizationId}`);
 export const getOrganizationPlaylists = async (organizationId: string) => readPath<Database.Playlists.Organization>(`playlists/organization/${organizationId}`);
 
@@ -142,3 +143,10 @@ export const writePath = async (path: string, data: any) => db.ref(path).set(dat
 export const pushPath = async (path: string, data: any) => db.ref(path).push(data);
 
 export const deletePath = async (path: string) => db.ref(path).remove();
+
+export const modifyPlaylistsResponse = (playlists: Database.Playlist[]) => {
+  return Object.values(playlists).map((playlist) => ({
+    ...playlist,
+    words: playlist.words.map((word) => word.map((letter) => (letter === false ? null : letter))),
+  }));
+};

--- a/src/lib/server/firebaseUtils.ts
+++ b/src/lib/server/firebaseUtils.ts
@@ -143,10 +143,3 @@ export const writePath = async (path: string, data: any) => db.ref(path).set(dat
 export const pushPath = async (path: string, data: any) => db.ref(path).push(data);
 
 export const deletePath = async (path: string) => db.ref(path).remove();
-
-export const modifyPlaylistsResponse = (playlists: Database.Playlist[]) => {
-  return Object.values(playlists).map((playlist) => ({
-    ...playlist,
-    words: playlist.words.map((word) => word.map((letter) => (letter === false ? null : letter))),
-  }));
-};

--- a/src/lib/server/firebaseUtils.ts
+++ b/src/lib/server/firebaseUtils.ts
@@ -58,6 +58,7 @@ export const getUserOrganizations = async (uid: string) => {
 };
 
 export const getOrganizationDecks = async (organizationId: string) => readPath<Database.Decks.Organization>(`decks/organization/${organizationId}`);
+export const getOrganizationPlaylists = async (organizationId: string) => readPath<Database.Playlists.Organization>(`playlists/organization/${organizationId}`);
 
 export const getOrganizationMemberDetails = async (organization: Database.Organization) => {
   const { members = {} } = organization.private ?? {};

--- a/src/routes/account/[uid]/+page.server.ts
+++ b/src/routes/account/[uid]/+page.server.ts
@@ -10,6 +10,7 @@ import {
   getCustomerPortalSession,
   PRICE_CODE,
   PRODUCT_CODE,
+  isOrganizationMember,
 } from '$lib/server/subscriptionUtils';
 import type Stripe from 'stripe';
 import { checkSessionAuth, readPath, writePath } from '$lib/server/firebaseUtils';
@@ -42,8 +43,10 @@ export const load = (async ({ params: { uid }, cookies }) => {
     };
   }
   const subscription = getBlendProSubscription(customer);
+  const hasOrganizationMembership = await isOrganizationMember(uid);
   return {
     isSubscribedToBlendPro: !!subscription,
+    hasOrganizationMembership,
     subscriptionPeriodEnd: subscription?.current_period_end ?? 0,
     subscriptionPendingCancellation: subscription?.cancel_at_period_end,
     organizations: JSON.stringify(await organizationPromise),

--- a/src/routes/account/[uid]/+page.server.ts
+++ b/src/routes/account/[uid]/+page.server.ts
@@ -33,17 +33,18 @@ export const load = (async ({ params: { uid }, cookies }) => {
     ),
   );
   const customer = await getStripeCustomerWithSubscriptions(uid);
+  const hasOrganizationMembership = await isOrganizationMember(uid);
 
   if (!customer || customer.deleted) {
     return {
       isSubscribedToBlendPro: false,
+      hasOrganizationMembership,
       subscriptionPeriodEnd: 0,
       subscriptionPendingCancellation: false,
       organizations: JSON.stringify(await organizationPromise),
     };
   }
   const subscription = getBlendProSubscription(customer);
-  const hasOrganizationMembership = await isOrganizationMember(uid);
   return {
     isSubscribedToBlendPro: !!subscription,
     hasOrganizationMembership,

--- a/src/routes/account/[uid]/+page.svelte
+++ b/src/routes/account/[uid]/+page.svelte
@@ -118,7 +118,7 @@
     <div class="detail">
       <h3>Your Blend Plan</h3>
       {#if isSubscribedToBlendPro}
-        <p>Blend PRO</p>
+        <p>Blend Pro</p>
         <div class="detail">
           <h3>Billing</h3>
           {#if subscriptionPendingCancellation}
@@ -140,8 +140,8 @@
           {/if}
         </div>
       {:else if hasOrganizationMembership}
-        <p>Blend PRO - Group License</p>
-        <p>You have Blend PRO access through your organization membership(s).</p>
+        <p>Blend Pro - Group License</p>
+        <p>You have Blend Pro access through your organization membership(s).</p>
         <br />
         <p>
           For questions about your access, please reach out to your organization admin 

--- a/src/routes/account/[uid]/+page.svelte
+++ b/src/routes/account/[uid]/+page.svelte
@@ -6,7 +6,7 @@
   import type { PageData } from './$types';
 
   export let data: PageData;
-  const { isSubscribedToBlendPro, subscriptionPendingCancellation, subscriptionPeriodEnd, organizations } = data;
+  const { isSubscribedToBlendPro, subscriptionPendingCancellation, subscriptionPeriodEnd, organizations, hasOrganizationMembership } = data;
   // Remove query params because they are handled on the server and any relevant state should be passed as a prop
   window.history.replaceState({}, document.title, window.location.toString().replace(window.location.search, ''));
 
@@ -139,6 +139,14 @@
             </form>
           {/if}
         </div>
+      {:else if hasOrganizationMembership}
+        <p>Blend PRO - Group License</p>
+        <p>You have Blend PRO access through your organization membership(s).</p>
+        <br />
+        <p>
+          For questions about your access, please reach out to your organization admin 
+          or email us at <a href="mailto:blend-support@csma.technology">blend-support@csma.technology.</a>
+        </p>
       {:else}
         <p>Blend Basic</p>
         <form action="?/createSubscriptionOrder" method="POST">

--- a/src/routes/api/playlists/user/+server.ts
+++ b/src/routes/api/playlists/user/+server.ts
@@ -1,14 +1,29 @@
-import { authenticate, readPath } from '$lib/server/firebaseUtils';
+import { authenticate, getOrganizationInfo, getOrganizationPlaylists, getUserOrganizations, modifyPlaylistsResponse, readPath } from '$lib/server/firebaseUtils';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET = (async (event) => {
   const { uid } = await authenticate(event);
-  const playlists = (await readPath(`/playlists/user/${uid}`)) || {};
-  const modifiedPlaylists = Object.values(playlists).map((playlist) => ({
-    ...playlist,
-    words: playlist.words.map((word) => Object.values(word).map((letters) => (letters === false ? null : letters))),
-  }));
+  const userPlaylists = (await readPath<Database.Playlists.User>(`/playlists/user/${uid}`)) || {};
+  const userPlaylistsArray = Object.values(userPlaylists).map((playlist) => playlist);
+  const organizationIds = await getUserOrganizations(uid);
+  const organizationPlaylistsArray = (
+    await Promise.all(
+      organizationIds.map(async (orgId) => {
+        const orgPlaylists = (await getOrganizationPlaylists(orgId) ?? {});
+        const orgInfo = await getOrganizationInfo(orgId);
+        return Object.values(orgPlaylists).map((playlist) => ({
+          ...playlist.playlist,
+          orgSource: {
+            orgName: orgInfo?.name,
+            orgId,
+          },
+        }))
+      })
+    )
+  ).flat();
+
+  const modifiedPlaylists = modifyPlaylistsResponse([...userPlaylistsArray, ...organizationPlaylistsArray]);
   return json(modifiedPlaylists, {
     headers: [['Access-Control-Allow-Origin', '*']],
   });

--- a/src/routes/api/playlists/user/+server.ts
+++ b/src/routes/api/playlists/user/+server.ts
@@ -1,4 +1,4 @@
-import { authenticate, getOrganizationInfo, getOrganizationPlaylists, getUserOrganizations, modifyPlaylistsResponse, readPath } from '$lib/server/firebaseUtils';
+import { authenticate, getOrganizationInfo, getOrganizationPlaylists, getUserOrganizations, readPath } from '$lib/server/firebaseUtils';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
@@ -23,7 +23,10 @@ export const GET = (async (event) => {
     )
   ).flat();
 
-  const modifiedPlaylists = modifyPlaylistsResponse([...userPlaylistsArray, ...organizationPlaylistsArray]);
+  const modifiedPlaylists = ([...userPlaylistsArray, ...organizationPlaylistsArray]).map((playlist) => ({
+    ...playlist,
+    words: playlist.words.map((word) => word.map((letter) => (letter === false ? null : letter))),
+  }));
   return json(modifiedPlaylists, {
     headers: [['Access-Control-Allow-Origin', '*']],
   });


### PR DESCRIPTION
- add section on org management page to add playlists to the organization similar to decks
![image](https://github.com/CSMA-Technology/blend-product-site/assets/6991957/d44f68a8-6e73-4910-857a-1b09ee43ba7c)
- add logic in user playlists API to merge the organization playlists for all orgs that the user is a member of with some metadata to differentiate from a normal user playlist
![image](https://github.com/CSMA-Technology/blend-product-site/assets/6991957/d9f8b283-4284-46c3-a358-bc036a9a0871)


- show accurate blend plan status according to organization subscriptions
![image](https://github.com/CSMA-Technology/blend-product-site/assets/6991957/c8bb6392-c73f-4b58-90cb-19612c194be2)
