### PR TITLE
feat(organizations): allow for reordering of org playlists and decks

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -123,7 +123,7 @@ declare global {
 
     namespace Organization {
       interface Member {
-        role: 'admin' | '';
+        role: 'admin' | 'member';
       }
       interface MemberDetails extends Member {
         displayName: string;

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -91,6 +91,9 @@ declare global {
       interface User {
         [deckId: string]: Deck;
       }
+      interface Preloaded {
+        [deckId: string]: Deck;
+      }
     }
     namespace Playlists {
       interface Organization {

--- a/src/routes/api/decks/preloaded/+server.ts
+++ b/src/routes/api/decks/preloaded/+server.ts
@@ -8,7 +8,7 @@ export const GET = (async (request) => {
   const decks = (await readPath<Database.Decks.Preloaded>('/decks/preloaded')) || {};
   const deckArray = Object.entries(decks).map(([key, val]) => val);
   if (user) {
-    const positionOffset = Math.max(...deckArray.map(({ position }) => position)) + 2; // +2 because legacy position can be -1, and we want the new position to be strictly greater
+    const positionOffset = Math.max(...deckArray.map(({ position }) => position)) + 2; // +2 because legacy position can be -1, and we want the new position to be strictly greater TODO: refactor this once we get rid of the legacy magic numbers in positioning
     const organizationIds = await getUserOrganizations(user.uid);
     organizationDeckArray = (
       await Promise.all(

--- a/src/routes/api/decks/preloaded/+server.ts
+++ b/src/routes/api/decks/preloaded/+server.ts
@@ -5,19 +5,20 @@ import type { RequestHandler } from './$types';
 export const GET = (async (request) => {
   let organizationDeckArray: Database.Deck[] = [];
   const user = await weaklyAuthenticate(request);
+  const decks = (await readPath<Database.Decks.Preloaded>('/decks/preloaded')) || {};
+  const deckArray = Object.entries(decks).map(([key, val]) => val);
   if (user) {
+    const positionOffset = Math.max(...deckArray.map(({ position }) => position)) + 2; // +2 because legacy position can be -1, and we want the new position to be strictly greater
     const organizationIds = await getUserOrganizations(user.uid);
     organizationDeckArray = (
       await Promise.all(
         organizationIds.map(async (orgId) => {
           const decks = (await getOrganizationDecks(orgId)) ?? {};
-          return Object.values(decks).map(({ deck }) => deck);
+          return Object.values(decks).map(({ deck }) => ({ ...deck, position: deck.position + positionOffset }));
         }),
       )
     ).flat();
   }
-  const decks = ((await readPath('/decks/preloaded')) as Object | null) || {};
-  const deckArray = Object.entries(decks).map(([key, val]) => val);
   return json([...deckArray, ...organizationDeckArray], {
     headers: [['Access-Control-Allow-Origin', '*']],
   });

--- a/src/routes/organization/[organizationId]/+page.svelte
+++ b/src/routes/organization/[organizationId]/+page.svelte
@@ -110,7 +110,7 @@
   };
 
   const demoteMember = (uid: string) => {
-    $organization!.private!.members![uid].role = '';
+    $organization!.private!.members![uid].role = 'member';
   };
 </script>
 

--- a/src/routes/organization/[organizationId]/+page.svelte
+++ b/src/routes/organization/[organizationId]/+page.svelte
@@ -51,6 +51,7 @@
   };
 
   const handleDeckAdd = () => {
+    let maxPosition = Math.max(...Object.values($organizationDecks ?? {}).map(({ deck: { position } }) => position), -1);
     const newDecks = decksToAdd.reduce((acc, deckId) => {
       const newRefId = Math.floor(Math.random() * 4294967295);
       return {
@@ -62,7 +63,7 @@
             ...$userDecks![deckId],
             refId: newRefId,
             is_editable: false,
-            position: -1,
+            position: ++maxPosition,
           },
         },
       };
@@ -72,6 +73,7 @@
     showDeckAddModal = false;
   };
   const handlePlaylistAdd = () => {
+    let maxPosition = Math.max(...Object.values($organizationPlaylists!).map(({ playlist: { position } }) => position), -1);
     const newPlaylists = playlistsToAdd.reduce((acc, playlistId) => {
       const newRefId = Math.floor(Math.random() * 4294967295);
       return {
@@ -83,7 +85,7 @@
             ...$userPlaylists![playlistId],
             refId: newRefId,
             is_editable: false,
-            position: -1,
+            position: ++maxPosition,
           },
         },
       };

--- a/src/routes/organization/[organizationId]/OrganizationItemTable.svelte
+++ b/src/routes/organization/[organizationId]/OrganizationItemTable.svelte
@@ -108,7 +108,7 @@
   <thead>
     <tr>
       {#if draggableItems}
-        <th></th>
+        <th style="width: 0;"></th>
       {/if}
       {#if selectable}
         <th></th>

--- a/src/routes/organization/[organizationId]/OrganizationItemTable.svelte
+++ b/src/routes/organization/[organizationId]/OrganizationItemTable.svelte
@@ -1,6 +1,7 @@
 <!-- Takes an array of Decks, Playlists, OrganizationDecks, or OrganizationPlaylists and renders them in a table -->
 <script lang="ts">
   import type { ChangeEventHandler } from 'svelte/elements';
+  import { scale } from 'svelte/transition';
   interface FlattenedItem {
     author?: string;
     created_ts: string;
@@ -8,19 +9,29 @@
     name: string;
     modified_ts: string;
     alreadyIncluded: boolean;
+    position: number;
   }
-  export let items: Database.Deck[] | Database.Playlist[] | Database.OrganizationDeck[] | Database.OrganizationPlaylist[] = [];
-  export let existingItems: Database.OrganizationDeck[] | Database.OrganizationPlaylist[] = [];
+  type Items = Database.Decks.Organization | Database.Playlists.Organization | Database.Decks.User | Database.Playlists.User;
+  export let items: Items = {};
+  export let existingItems: Database.Decks.Organization | Database.Playlists.Organization = {};
   export let memberDetails: Database.Organization.MemberDetails[] = [];
   export let selectable = false;
   export let selectedItems: string[] = [];
   export let itemActions: { name: string; class?: string; handler: (item: FlattenedItem) => any }[] = [];
-  $: flattenedItems = items
+  export let draggableItems = false;
+  export let onItemReorder: (itemIdsInOrder: string[]) => any = () => {};
+
+  const compareItems = (item1: { created_ts: string; position: number }, item2: { created_ts: string; position: number }) => {
+    if (item1.position !== item2.position) {
+      return item1.position - item2.position;
+    }
+    return item1.created_ts.localeCompare(item2.created_ts);
+  };
+
+  $: flattenedItems = Object.values(items)
     .map<FlattenedItem>((item) => {
       return {
-        //@ts-expect-error
         ...item.deck,
-        //@ts-expect-error
         ...item.playlist,
         ...item,
       };
@@ -28,11 +39,12 @@
     .map((item) => ({
       ...item,
       author: item.author ? memberDetails.find(({ uid }) => uid === item.author)?.displayName : undefined,
-      alreadyIncluded: !!existingItems.find((existingItem) => {
+      alreadyIncluded: !!Object.values(existingItems).find((existingItem) => {
         if ('deck' in existingItem) return String(item.refId) === existingItem.originalRefId && existingItem.deck.modified_ts === item.modified_ts;
         else return String(item.refId) === existingItem.originalRefId && existingItem.playlist.modified_ts === item.modified_ts;
       }),
-    }));
+    }))
+    .sort(compareItems);
 
   const handleItemCheck: ChangeEventHandler<HTMLInputElement> = (e) => {
     const target = e.target as HTMLInputElement;
@@ -50,11 +62,54 @@
       selectedItems = selectedItems.filter((id) => id !== target.value);
     }
   };
+
+  let placeholderPosition: number | null = null;
+  let isDragging = false;
+
+  const handleDragStart = (event: DragEvent, index: number) => {
+    event.dataTransfer?.setData('text/plain', String(index));
+    event.dataTransfer?.setDragImage((event.currentTarget as Element)?.closest('tr')!, 0, 0);
+    isDragging = true;
+  };
+
+  const handleDragEnd = () => {
+    isDragging = false;
+  };
+
+  const handleDragOver = (event: DragEvent, index: number) => {
+    if (!isDragging) return;
+    event.preventDefault();
+    event.dataTransfer!.dropEffect = 'move';
+    placeholderPosition = index;
+  };
+
+  const handleDragLeave = () => {
+    placeholderPosition = null;
+  };
+
+  const handleDrop = (event: DragEvent, dropIndex: number) => {
+    event.preventDefault();
+    placeholderPosition = null;
+    const draggedItemIndex = Number(event.dataTransfer?.getData('text/plain'));
+    if (draggedItemIndex !== dropIndex) {
+      const destinationIndex = dropIndex > draggedItemIndex ? dropIndex - 1 : dropIndex;
+      const newItems = flattenedItems
+        .slice(0, draggedItemIndex)
+        .concat(flattenedItems.slice(draggedItemIndex + 1))
+        .toSpliced(destinationIndex, 0, flattenedItems[draggedItemIndex]);
+      console.log('New items:', newItems);
+      onItemReorder(newItems.map((item) => String(item.refId)));
+    }
+    isDragging = false;
+  };
 </script>
 
 <table>
   <thead>
     <tr>
+      {#if draggableItems}
+        <th></th>
+      {/if}
       {#if selectable}
         <th></th>
       {/if}
@@ -72,13 +127,34 @@
   <tbody>
     {#if selectable}
       <tr>
-        <!-- Make this only fill the first column and not all 4 -->
         <td><input type="checkbox" value="all" on:change={handleItemCheck} checked={selectedItems.length === flattenedItems.length} /></td>
         <td><em>{`${selectedItems.length !== flattenedItems.length ? 'Select All' : 'Unselect All'}`}</em></td>
       </tr>
     {/if}
-    {#each flattenedItems as item (item.refId)}
-      <tr>
+    {#each flattenedItems as item, index (item.refId)}
+      {#if placeholderPosition === index}
+        <tr class="placeholder" in:scale>
+          <td colspan={6}></td>
+        </tr>
+      {:else}
+        <tr class="spacer">
+          <td colspan={6}></td>
+        </tr>
+      {/if}
+      <tr on:dragover={(event) => handleDragOver(event, index)} on:drop={(event) => handleDrop(event, index)} on:dragleave={handleDragLeave}>
+        {#if draggableItems}
+          <td>
+            <span
+              draggable="true"
+              role="button"
+              tabindex={0}
+              on:dragstart={(event) => handleDragStart(event, index)}
+              on:dragend={handleDragEnd}
+              class="drag-handle"
+              >&#9776;
+            </span>
+          </td>
+        {/if}
         {#if selectable}
           <td
             ><input
@@ -120,6 +196,30 @@
     width: fit-content;
     line-height: 1.2rem;
     padding: 0.3rem;
+  }
+
+  .drag-handle {
+    cursor: grab;
+  }
+
+  .placeholder {
+    height: 2px !important; /* Adjust height to your preference */
+    background-color: #666; /* Adjust color to your preference */
+  }
+
+  .spacer {
+    height: 2px !important; /* Adjust height to your preference */
+    background-color: #ffffff00; /* Adjust color to your preference */
+  }
+
+  .spacer > td {
+    height: 0 !important;
+    padding: 0 !important;
+  }
+
+  .placeholder > td {
+    height: 0 !important;
+    padding: 0 !important;
   }
 
   .name {


### PR DESCRIPTION
Implemented it with drag and drop, which works okay but is not accessible
![image](https://github.com/CSMA-Technology/blend-product-site/assets/10676387/156355e1-d15c-4f95-a170-c8664dc34217)

Also changed the demote behavior to assign a role of `member` instead of an empty string