### PR TITLE
***DO NOT MERGE UNTIL APP BRANCH IS READY*** feat(org-decks-api): moved retrieval of org decks to /decks/user

### DIFF
--- a/src/routes/api/decks/preloaded/+server.ts
+++ b/src/routes/api/decks/preloaded/+server.ts
@@ -3,23 +3,10 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET = (async (request) => {
-  let organizationDeckArray: Database.Deck[] = [];
   const user = await weaklyAuthenticate(request);
   const decks = (await readPath<Database.Decks.Preloaded>('/decks/preloaded')) || {};
   const deckArray = Object.entries(decks).map(([key, val]) => val);
-  if (user) {
-    const positionOffset = Math.max(...deckArray.map(({ position }) => position)) + 2; // +2 because legacy position can be -1, and we want the new position to be strictly greater TODO: refactor this once we get rid of the legacy magic numbers in positioning
-    const organizationIds = await getUserOrganizations(user.uid);
-    organizationDeckArray = (
-      await Promise.all(
-        organizationIds.map(async (orgId) => {
-          const decks = (await getOrganizationDecks(orgId)) ?? {};
-          return Object.values(decks).map(({ deck }) => ({ ...deck, position: deck.position + positionOffset }));
-        }),
-      )
-    ).flat();
-  }
-  return json([...deckArray, ...organizationDeckArray], {
+  return json(deckArray, {
     headers: [['Access-Control-Allow-Origin', '*']],
   });
 }) satisfies RequestHandler;

--- a/src/routes/api/decks/user/+server.ts
+++ b/src/routes/api/decks/user/+server.ts
@@ -1,12 +1,31 @@
-import { authenticate, getUserData, readPath } from '$lib/server/firebaseUtils';
+import { authenticate, getOrganizationDecks, getOrganizationInfo, getUserData, getUserOrganizations, readPath } from '$lib/server/firebaseUtils';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET = (async (event) => {
+  let organizationDeckArray: Database.Deck[] = [];
   const { uid } = await authenticate(event);
-  const decks = (await readPath(`/decks/user/${uid}`)) || {};
+  const decks = (await readPath<Database.Decks.User>(`/decks/user/${uid}`)) || {};
   const deckArray = Object.entries(decks).map(([key, val]) => val);
-  return json(deckArray, {
+  const positionOffset = Math.max(...deckArray.map(({ position }) => position)) + 2; // +2 because legacy position can be -1, and we want the new position to be strictly greater TODO: refactor this once we get rid of the legacy magic numbers in positioning
+  const organizationIds = await getUserOrganizations(uid);
+  organizationDeckArray = (
+    await Promise.all(
+      organizationIds.map(async (orgId) => {
+        const decks = (await getOrganizationDecks(orgId)) ?? {};
+        const orgInfo = await getOrganizationInfo(orgId);
+        return Object.values(decks).map(({ deck }) => ({ 
+          ...deck, 
+          position: deck.position + positionOffset,
+          orgSource: {
+            orgName: orgInfo?.name,
+            orgId,
+          },
+        }));
+      }),
+    )
+  ).flat();
+  return json([...deckArray, ...organizationDeckArray], {
     headers: [['Access-Control-Allow-Origin', '*']],
   });
 }) satisfies RequestHandler;


### PR DESCRIPTION
Moved logic to get all of a user's org decks to `/decks/user` to be consistent with the Playlists API. Also added a section in each org deck's object for the `orgInfo` containing its name and its org ID. 

This works in conjunction with the app's dropdown filter menu on the home screen.

_**THIS CODE SHOULD BE RELEASED SIMULTANEOUSLY WITH THE APP CHANGES**_