### PR TITLE
fix(firebase): used completion callback for write functions

### DIFF
--- a/src/lib/server/firebaseUtils.ts
+++ b/src/lib/server/firebaseUtils.ts
@@ -144,8 +144,26 @@ export const readPath = async <T = any>(path: string, defaultValue: T | null = n
   return (data.val() as T | null) ?? defaultValue;
 };
 
-export const writePath = async (path: string, data: any) => db.ref(path).set(data);
+export const writePath = async (path: string, data: any) =>
+  new Promise<void>((resolve, reject) => {
+    db.ref(path).set(data, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
 
-export const pushPath = async (path: string, data: any) => db.ref(path).push(data);
+export const pushPath = async (path: string, data: any) =>
+  new Promise<void>((resolve, reject) => {
+    db.ref(path).push(data, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
 
-export const deletePath = async (path: string) => db.ref(path).remove();
+export const deletePath = async (path: string) =>
+  new Promise<void>((resolve, reject) => {
+    db.ref(path).remove((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });


### PR DESCRIPTION
The firebase `set`, `push`, and `remove` functions return promises, so previously we were just `await`ing those promises. But those promises do not resolve when the actual operation is completed, Firebase will queue those operations and then resolve that promise. 

In the case where the connection to Firebase is hot, it would almost always finish writing the data immediately, probably before the browser even got the result of the request. But in the case where the connection is cold, the the function first has to connect to Firebase and then the operation will be performed, but the client has already been responded to and it proceeds. 

Anyway, there is a second argument to all those functions which is a completion callback , which only gets called once the change is committed in the DB. So now we are using that instead. 