### PR TITLE
feat(decks-api-filter): allow query params to filter user decks response

### DIFF
--- a/src/routes/api/decks/user/+server.ts
+++ b/src/routes/api/decks/user/+server.ts
@@ -6,54 +6,55 @@ export const GET = (async (event) => {
   const { uid } = await authenticate(event);
   const omitOrgDecks = event.url.searchParams.get('omitOrgDecks') ?? false;
   const orgIdParam = event.url.searchParams.get('orgId');
-  if (omitOrgDecks && orgIdParam) return new Response('Cannot specify both omitOrgDecks and orgId', {status: 400, headers: [['Access-Control-Allow-Origin', '*']]});
+  if (omitOrgDecks && orgIdParam)
+    return new Response('Cannot specify both omitOrgDecks and orgId', { status: 400, headers: [['Access-Control-Allow-Origin', '*']] });
   if (omitOrgDecks) {
     const userDecks = (await readPath<Database.Decks.User>(`/decks/user/${uid}`)) || {};
-      const deckArray = Object.entries(userDecks).map(([key, val]) => val);
-      return json(deckArray, {
-        headers: [['Access-Control-Allow-Origin', '*']],
-      });
+    const deckArray = Object.entries(userDecks).map(([key, val]) => val);
+    return json(deckArray, {
+      headers: [['Access-Control-Allow-Origin', '*']],
+    });
   } else if (orgIdParam) {
     const organizationIds = await getUserOrganizations(uid);
-    if (!organizationIds.includes(orgIdParam)) return new Response('User is not a member of this organization', {status: 403, headers: [['Access-Control-Allow-Origin', '*']]});
-        const orgDecks = (await getOrganizationDecks(orgIdParam)) ?? {};
-        const organizationInfo = await getOrganizationInfo(orgIdParam);
-        const deckArray = Object.values(orgDecks).map(({ deck }) => ({
-          ...deck,
-          orgSource: {
-            orgName: organizationInfo?.name,
-            orgId: orgIdParam,
-          },
-        
-        }));
-        return json(deckArray, {
-          headers: [['Access-Control-Allow-Origin', '*']],
-        });
+    if (!organizationIds.includes(orgIdParam))
+      return new Response('User is not a member of this organization', { status: 403, headers: [['Access-Control-Allow-Origin', '*']] });
+    const orgDecks = (await getOrganizationDecks(orgIdParam)) ?? {};
+    const organizationInfo = await getOrganizationInfo(orgIdParam);
+    const deckArray = Object.values(orgDecks).map(({ deck }) => ({
+      ...deck,
+      orgSource: {
+        orgName: organizationInfo?.name,
+        orgId: orgIdParam,
+      },
+    }));
+    return json(deckArray, {
+      headers: [['Access-Control-Allow-Origin', '*']],
+    });
   } else {
     const userDecks = (await readPath<Database.Decks.User>(`/decks/user/${uid}`)) || {};
-      const userDeckArray = Object.entries(userDecks).map(([key, val]) => val);
-      const positionOffset = Math.max(...userDeckArray.map(({ position }) => position), 0) + 2; // +2 because legacy position can be -1, and we want the new position to be strictly greater TODO: refactor this once we get rid of the legacy magic numbers in positioning
-      const organizationIds = await getUserOrganizations(uid);
-      const organizationDeckArray = (
-        await Promise.all(
-          organizationIds.map(async (orgId) => {
-            const orgDecks = (await getOrganizationDecks(orgId)) ?? {};
-            const orgInfo = await getOrganizationInfo(orgId);
-            return Object.values(orgDecks).map(({ deck }) => ({
-              ...deck,
-              position: deck.position + positionOffset,
-              orgSource: {
-                orgName: orgInfo?.name,
-                orgId,
-              },
-            }));
-          }),
-        )
-      ).flat();
+    const userDeckArray = Object.entries(userDecks).map(([key, val]) => val);
+    const positionOffset = Math.max(...userDeckArray.map(({ position }) => position), 0) + 2; // +2 because legacy position can be -1, and we want the new position to be strictly greater TODO: refactor this once we get rid of the legacy magic numbers in positioning
+    const organizationIds = await getUserOrganizations(uid);
+    const organizationDeckArray = (
+      await Promise.all(
+        organizationIds.map(async (orgId) => {
+          const orgDecks = (await getOrganizationDecks(orgId)) ?? {};
+          const orgInfo = await getOrganizationInfo(orgId);
+          return Object.values(orgDecks).map(({ deck }) => ({
+            ...deck,
+            position: deck.position + positionOffset,
+            orgSource: {
+              orgName: orgInfo?.name,
+              orgId,
+            },
+          }));
+        }),
+      )
+    ).flat();
 
-      return json([...userDeckArray, ...organizationDeckArray], {
-        headers: [['Access-Control-Allow-Origin', '*']],
-      });
+    return json([...userDeckArray, ...organizationDeckArray], {
+      headers: [['Access-Control-Allow-Origin', '*']],
+    });
   }
 }) satisfies RequestHandler;
 

--- a/src/routes/api/decks/user/+server.ts
+++ b/src/routes/api/decks/user/+server.ts
@@ -4,21 +4,18 @@ import type { RequestHandler } from './$types';
 
 export const GET = (async (event) => {
   const { uid } = await authenticate(event);
-  const viewParam = event.url.searchParams.get('view');
+  const omitOrgDecks = event.url.searchParams.get('omitOrgDecks') ?? false;
   const orgIdParam = event.url.searchParams.get('orgId');
-  if (orgIdParam && !viewParam) return new Response('If orgId is provided, view must be set to org', {status: 400, headers: [['Access-Control-Allow-Origin', '*']]});
-  switch (viewParam) {
-    case 'user': {
-      const userDecks = (await readPath<Database.Decks.User>(`/decks/user/${uid}`)) || {};
+  if (omitOrgDecks && orgIdParam) return new Response('Cannot specify both omitOrgDecks and orgId', {status: 400, headers: [['Access-Control-Allow-Origin', '*']]});
+  if (omitOrgDecks) {
+    const userDecks = (await readPath<Database.Decks.User>(`/decks/user/${uid}`)) || {};
       const deckArray = Object.entries(userDecks).map(([key, val]) => val);
       return json(deckArray, {
         headers: [['Access-Control-Allow-Origin', '*']],
       });
-    }
-    case 'org': {
-      const organizationIds = await getUserOrganizations(uid);
-      if (orgIdParam) {
-        if (!organizationIds.includes(orgIdParam)) return new Response('User is not a member of this organization', {status: 403, headers: [['Access-Control-Allow-Origin', '*']]});
+  } else if (orgIdParam) {
+    const organizationIds = await getUserOrganizations(uid);
+    if (!organizationIds.includes(orgIdParam)) return new Response('User is not a member of this organization', {status: 403, headers: [['Access-Control-Allow-Origin', '*']]});
         const orgDecks = (await getOrganizationDecks(orgIdParam)) ?? {};
         const organizationInfo = await getOrganizationInfo(orgIdParam);
         const deckArray = Object.values(orgDecks).map(({ deck }) => ({
@@ -32,29 +29,8 @@ export const GET = (async (event) => {
         return json(deckArray, {
           headers: [['Access-Control-Allow-Origin', '*']],
         });
-      } else {
-        const organizationDeckArray = (
-          await Promise.all(
-            organizationIds.map(async (orgId) => {
-              const decks = (await getOrganizationDecks(orgId)) ?? {};
-              const orgInfo = await getOrganizationInfo(orgId);
-              return Object.values(decks).map(({ deck }) => ({
-                ...deck,
-                orgSource: {
-                  orgName: orgInfo?.name,
-                  orgId,
-                },
-              }));
-            }),
-          )
-        ).flat();
-        return json(organizationDeckArray, {
-          headers: [['Access-Control-Allow-Origin', '*']],
-        });
-      }
-    }
-    default: {
-      const userDecks = (await readPath<Database.Decks.User>(`/decks/user/${uid}`)) || {};
+  } else {
+    const userDecks = (await readPath<Database.Decks.User>(`/decks/user/${uid}`)) || {};
       const userDeckArray = Object.entries(userDecks).map(([key, val]) => val);
       const positionOffset = Math.max(...userDeckArray.map(({ position }) => position), 0) + 2; // +2 because legacy position can be -1, and we want the new position to be strictly greater TODO: refactor this once we get rid of the legacy magic numbers in positioning
       const organizationIds = await getUserOrganizations(uid);
@@ -78,7 +54,6 @@ export const GET = (async (event) => {
       return json([...userDeckArray, ...organizationDeckArray], {
         headers: [['Access-Control-Allow-Origin', '*']],
       });
-    }
   }
 }) satisfies RequestHandler;
 

--- a/src/routes/api/decks/user/+server.ts
+++ b/src/routes/api/decks/user/+server.ts
@@ -1,33 +1,85 @@
-import { authenticate, getOrganizationDecks, getOrganizationInfo, getUserData, getUserOrganizations, readPath } from '$lib/server/firebaseUtils';
+import { authenticate, getOrganizationDecks, getOrganizationInfo, getUserOrganizations, readPath } from '$lib/server/firebaseUtils';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET = (async (event) => {
-  let organizationDeckArray: Database.Deck[] = [];
   const { uid } = await authenticate(event);
-  const decks = (await readPath<Database.Decks.User>(`/decks/user/${uid}`)) || {};
-  const deckArray = Object.entries(decks).map(([key, val]) => val);
-  const positionOffset = Math.max(...deckArray.map(({ position }) => position), 0) + 2; // +2 because legacy position can be -1, and we want the new position to be strictly greater TODO: refactor this once we get rid of the legacy magic numbers in positioning
-  const organizationIds = await getUserOrganizations(uid);
-  organizationDeckArray = (
-    await Promise.all(
-      organizationIds.map(async (orgId) => {
-        const decks = (await getOrganizationDecks(orgId)) ?? {};
-        const orgInfo = await getOrganizationInfo(orgId);
-        return Object.values(decks).map(({ deck }) => ({
+  const viewParam = event.url.searchParams.get('view');
+  const orgIdParam = event.url.searchParams.get('orgId');
+  if (orgIdParam && !viewParam) return new Response('If orgId is provided, view must be set to org', {status: 400, headers: [['Access-Control-Allow-Origin', '*']]});
+  switch (viewParam) {
+    case 'user': {
+      const userDecks = (await readPath<Database.Decks.User>(`/decks/user/${uid}`)) || {};
+      const deckArray = Object.entries(userDecks).map(([key, val]) => val);
+      return json(deckArray, {
+        headers: [['Access-Control-Allow-Origin', '*']],
+      });
+    }
+    case 'org': {
+      const organizationIds = await getUserOrganizations(uid);
+      if (orgIdParam) {
+        if (!organizationIds.includes(orgIdParam)) return new Response('User is not a member of this organization', {status: 403, headers: [['Access-Control-Allow-Origin', '*']]});
+        const orgDecks = (await getOrganizationDecks(orgIdParam)) ?? {};
+        const organizationInfo = await getOrganizationInfo(orgIdParam);
+        const deckArray = Object.values(orgDecks).map(({ deck }) => ({
           ...deck,
-          position: deck.position + positionOffset,
           orgSource: {
-            orgName: orgInfo?.name,
-            orgId,
+            orgName: organizationInfo?.name,
+            orgId: orgIdParam,
           },
+        
         }));
-      }),
-    )
-  ).flat();
-  return json([...deckArray, ...organizationDeckArray], {
-    headers: [['Access-Control-Allow-Origin', '*']],
-  });
+        return json(deckArray, {
+          headers: [['Access-Control-Allow-Origin', '*']],
+        });
+      } else {
+        const organizationDeckArray = (
+          await Promise.all(
+            organizationIds.map(async (orgId) => {
+              const decks = (await getOrganizationDecks(orgId)) ?? {};
+              const orgInfo = await getOrganizationInfo(orgId);
+              return Object.values(decks).map(({ deck }) => ({
+                ...deck,
+                orgSource: {
+                  orgName: orgInfo?.name,
+                  orgId,
+                },
+              }));
+            }),
+          )
+        ).flat();
+        return json(organizationDeckArray, {
+          headers: [['Access-Control-Allow-Origin', '*']],
+        });
+      }
+    }
+    default: {
+      const userDecks = (await readPath<Database.Decks.User>(`/decks/user/${uid}`)) || {};
+      const userDeckArray = Object.entries(userDecks).map(([key, val]) => val);
+      const positionOffset = Math.max(...userDeckArray.map(({ position }) => position), 0) + 2; // +2 because legacy position can be -1, and we want the new position to be strictly greater TODO: refactor this once we get rid of the legacy magic numbers in positioning
+      const organizationIds = await getUserOrganizations(uid);
+      const organizationDeckArray = (
+        await Promise.all(
+          organizationIds.map(async (orgId) => {
+            const orgDecks = (await getOrganizationDecks(orgId)) ?? {};
+            const orgInfo = await getOrganizationInfo(orgId);
+            return Object.values(orgDecks).map(({ deck }) => ({
+              ...deck,
+              position: deck.position + positionOffset,
+              orgSource: {
+                orgName: orgInfo?.name,
+                orgId,
+              },
+            }));
+          }),
+        )
+      ).flat();
+
+      return json([...userDeckArray, ...organizationDeckArray], {
+        headers: [['Access-Control-Allow-Origin', '*']],
+      });
+    }
+  }
 }) satisfies RequestHandler;
 
 export const OPTIONS = (() => {

--- a/src/routes/api/user/+server.ts
+++ b/src/routes/api/user/+server.ts
@@ -1,4 +1,4 @@
-import { authenticate, getUserData } from '$lib/server/firebaseUtils';
+import { authenticate, getOrganizationInfo, getOrganizationMemberDetails, getUserData, getUserOrganizations } from '$lib/server/firebaseUtils';
 import { getBlendProSubscription, getStripeCustomerWithSubscriptions, isOrganizationMember, isSubscribedToBlendPro } from '$lib/server/subscriptionUtils';
 import type { RequestHandler } from './$types';
 
@@ -6,10 +6,23 @@ export const GET = (async (event) => {
   const { uid } = await authenticate(event);
   const [stripeCustomer, firebaseUserData] = await Promise.all([getStripeCustomerWithSubscriptions(uid), getUserData(uid)]);
   const subscriptionData = stripeCustomer && !stripeCustomer.deleted && getBlendProSubscription(stripeCustomer);
+  const userOrganizations = await getUserOrganizations(uid);
+  const organizationInfo = (
+    await Promise.all(
+      userOrganizations.map(async (orgId) => {
+        const orgInfo = await getOrganizationInfo(orgId);
+        return {
+            orgName: orgInfo?.name,
+            orgId,
+        }
+      }),
+    )
+  );
   const userData = {
     ...firebaseUserData,
     isSubscribedToBlendPro: (await isOrganizationMember(uid)) || isSubscribedToBlendPro(stripeCustomer),
     subscriptionPeriodEnd: subscriptionData ? subscriptionData.current_period_end : 0,
+    organizationInfo,
   };
   return new Response(JSON.stringify(userData, null, 2), {
     headers: [['Access-Control-Allow-Origin', '*']],

--- a/src/routes/api/user/+server.ts
+++ b/src/routes/api/user/+server.ts
@@ -1,5 +1,10 @@
 import { authenticate, getOrganizationInfo, getOrganizationMemberDetails, getUserData, getUserOrganizations } from '$lib/server/firebaseUtils';
-import { getBlendProSubscription, getStripeCustomerWithSubscriptions, isOrganizationMember, isSubscribedToBlendPro } from '$lib/server/subscriptionUtils';
+import {
+  getBlendProSubscription,
+  getStripeCustomerWithSubscriptions,
+  isOrganizationMember,
+  isSubscribedToBlendPro,
+} from '$lib/server/subscriptionUtils';
 import type { RequestHandler } from './$types';
 
 export const GET = (async (event) => {
@@ -7,16 +12,14 @@ export const GET = (async (event) => {
   const [stripeCustomer, firebaseUserData] = await Promise.all([getStripeCustomerWithSubscriptions(uid), getUserData(uid)]);
   const subscriptionData = stripeCustomer && !stripeCustomer.deleted && getBlendProSubscription(stripeCustomer);
   const userOrganizations = await getUserOrganizations(uid);
-  const organizationInfo = (
-    await Promise.all(
-      userOrganizations.map(async (orgId) => {
-        const orgInfo = await getOrganizationInfo(orgId);
-        return {
-            orgName: orgInfo?.name,
-            orgId,
-        }
-      }),
-    )
+  const organizationInfo = await Promise.all(
+    userOrganizations.map(async (orgId) => {
+      const orgInfo = await getOrganizationInfo(orgId);
+      return {
+        orgName: orgInfo?.name,
+        orgId,
+      };
+    }),
   );
   const userData = {
     ...firebaseUserData,


### PR DESCRIPTION
Query Params on `/decks/user`

- `omitOrgDecks` - if passed, omits all organization decks from the response showing only the user's custom decks. This takes precedence over the `orgId` filter and will return a 400 if both params are passed
- `orgId` - if passed, return only the decks for that org
  - If the `orgId` param passed is not an organization that user is a member of, return `403`