### PR TITLE
feat(annual-subscription): added annual subscription option to Stripe checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "pre-commit": "^1.2.2",
         "prettier": "^3.0.2",
         "prettier-plugin-svelte": "^3.0.3",
-        "stripe": "^12.18.0",
+        "stripe": "^14.24.0",
         "svelte": "^4.2.0",
         "svelte-check": "^3.5.0",
         "tslib": "^2.6.1",
@@ -6027,9 +6027,9 @@
       }
     },
     "node_modules/stripe": {
-      "version": "12.18.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-12.18.0.tgz",
-      "integrity": "sha512-cYjgBM2SY/dTm8Lr6eMyyONaHTZHA/QjHxFUIW5WH8FevSRIGAVtXEmBkUXF1fsqe7QvvRgQSGSJZmjDacegGg==",
+      "version": "14.24.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-14.24.0.tgz",
+      "integrity": "sha512-r0JWz2quThXsFbp1pevkAAoDk4sw3kFMQEc2qvxMFUOhw/SFGqtAGz4vQgP/fMWzO28ljBNEiz68KqRx0JS3dw==",
       "dev": true,
       "dependencies": {
         "@types/node": ">=8.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^3.0.2",
     "prettier-plugin-svelte": "^3.0.3",
-    "stripe": "^12.18.0",
+    "stripe": "^14.24.0",
     "svelte": "^4.2.0",
     "svelte-check": "^3.5.0",
     "tslib": "^2.6.1",

--- a/src/routes/account/+page.server.ts
+++ b/src/routes/account/+page.server.ts
@@ -51,7 +51,10 @@ export const load = (async ({ url, cookies }) => {
             token ? `&context=${encodeURIComponent(JSON.stringify({ token }))}` : ''
           }`;
         }
-        const stripeSession = await createStripeSession(uid, email, name, url.origin, successUrl);
+        const stripeSession = await createStripeSession(uid, email, name, url.origin, {
+          successUrl,
+          subscriptionType: newParams.get('subscriptionType') === 'yearly' ? 'yearly' : 'monthly',
+        });
         throw redirect(303, stripeSession.url!);
       }
       case 'choosePlan':

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -53,6 +53,8 @@
     selectedOrgId = orgId;
     showOrgLeaveConfirmation = true;
   };
+
+  let isCreatingSubscriptionOrder = false;
 </script>
 
 <svelte:head>
@@ -151,11 +153,16 @@
         </p>
       {:else}
         <p>Blend Basic</p>
-        <form action="?/createSubscriptionOrder" method="POST">
+        <form
+          action="?/createSubscriptionOrder"
+          on:submit={() => {
+            isCreatingSubscriptionOrder = true;
+          }}
+          method="POST">
           <input type="hidden" name="email" value={$user?.email} />
           <input type="hidden" name="name" value={$user?.displayName} />
           <input type="hidden" name="uid" value={$user?.uid} />
-          <button id="checkout-and-portal-button" type="submit" class="btn">Upgrade to Blend Pro</button>
+          <button id="checkout-and-portal-button" type="submit" disabled={isCreatingSubscriptionOrder} class="btn">Upgrade to Blend Pro</button>
         </form>
       {/if}
     </div>


### PR DESCRIPTION
This adds the ability to switch between yearly or monthly subs. It adds a little text right above the `subscribe` button:
![image](https://github.com/CSMA-Technology/blend-product-site/assets/10676387/f4920a4b-fc17-457c-95b9-6fde5c6fe2b5)

And also more importantly if we want to link people directly to it we **do not** use the Stripe checkout link, but just send them a link to `https://blendreading.com/account?action=upgrade&subscriptionType=yearly`

There is one hitch to this solution. Stripe lets you put custom text and a link there, but it opens the link in the same page. Which means the user will have the other tab with the other subscription still open. I tested and it does let you subscribe to both. So what I had to do is add code to when we create a Stripe checkout session to invalidate all other sessions open for that user. The previous sessions will then fail if they try to check out, and unfortunately they will fail with this ugly message, which we cannot change:
![image](https://github.com/CSMA-Technology/blend-product-site/assets/10676387/164722f3-a89c-4d02-89ca-1ef818c92611)

Not ideal, but lmk if you can think of a better way to handle it