### PR TITLE
fix(login): retain all params when redirecting to account

### DIFF
--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -17,6 +17,10 @@
   const searchParams = new URLSearchParams(decodeURIComponent($page.url.search));
   const redirectParam = searchParams.get('successRedirect') || '/';
   const actionParam = searchParams.get('action') || '';
+  const allOtherParams = Array.from(searchParams.entries())
+    .filter(([key]) => key !== 'successRedirect' && key !== 'action')
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
 
   type RedirectBuilderFunc = (user: User, token?: string) => string;
   let redirectBuilder: RedirectBuilderFunc;
@@ -24,7 +28,10 @@
   switch (redirectParam) {
     case 'account':
     case '/':
-      redirectBuilder = () => (actionParam ? `/account?action=${actionParam}` : '/account');
+      redirectBuilder = () =>
+        actionParam
+          ? `/account?action=${actionParam}${allOtherParams ? `&${allOtherParams}` : ''}`
+          : `/account${allOtherParams ? `?${allOtherParams}` : ''}`;
       break;
     case 'app':
       if (actionParam) {


### PR DESCRIPTION
All other params except `action` where getting dropped when redirecting to the account page after a login, so I added them in explicitly. Now we can link to the yearly subscription and it will work for new members. 