### PR TITLE
feat(apis): cache rarely modified resources

### DIFF
--- a/src/routes/api/decks/preloaded/+server.ts
+++ b/src/routes/api/decks/preloaded/+server.ts
@@ -5,7 +5,7 @@ import type { RequestHandler } from './$types';
 export const GET = (async (request) => {
   const decks = (await readPath<Database.Decks.Preloaded>('/decks/preloaded')) || {};
   const deckArray = Object.entries(decks).map(([key, val]) => val);
-  return json(deckArray);
+  return json(deckArray, { headers: [['Cache-Control', 'must-revalidate, max-age=3600, stale-while-revalidate=604800']] });
 }) satisfies RequestHandler;
 
 export const OPTIONS = (() => {

--- a/src/routes/api/playlists/library/+server.ts
+++ b/src/routes/api/playlists/library/+server.ts
@@ -11,7 +11,9 @@ export const GET = (async (request) => {
     words: transformPlaylistForClient(playlist) ?? [],
   }));
   const filteredPlaylists = filterAttributes(attributes, playlistArray);
-  return json(filteredPlaylists.some((playlist: Database.Playlist) => Object.keys(playlist).length > 0) ? filteredPlaylists : playlistArray);
+  return json(filteredPlaylists.some((playlist: Database.Playlist) => Object.keys(playlist).length > 0) ? filteredPlaylists : playlistArray, {
+    headers: [['Cache-Control', 'must-revalidate, max-age=3600, stale-while-revalidate=604800']],
+  });
 }) satisfies RequestHandler;
 
 export const OPTIONS = (() => {

--- a/src/routes/api/playlists/preloaded/+server.ts
+++ b/src/routes/api/playlists/preloaded/+server.ts
@@ -9,7 +9,7 @@ export const GET = (async (request) => {
     ...playlist,
     words: transformPlaylistForClient(playlist) ?? [],
   }));
-  return json(playlistArray);
+  return json(playlistArray, { headers: [['Cache-Control', 'must-revalidate, max-age=3600, stale-while-revalidate=604800']] });
 }) satisfies RequestHandler;
 
 export const OPTIONS = (() => {


### PR DESCRIPTION
I added cache control headers to `/decks/preloaded` `/playlists/preloaded` and `/playlists/library`. 

The header is the same in all three cases: `{ headers: [['Cache-Control', 'must-revalidate, max-age=3600, stale-while-revalidate=604800']] }`

What this means in english:
- Browser can cache the result and use it from the cache for one hour without checking with the server.
- After one hour but before one week, the browser can still use the cached result, but in the background it must fetch it again and refresh its cached copy. **Except in Safari**. Safari does not support the otherwise standard `stale-while-revalidate` header, so Safari will not use the stale version after an hour, it will fetch a new one.
- After a week, it throws out the cached version and fetches a new one, and it will wait for that result (not serve the stale one). 