### PR TITLE
feat(firebase): added function to cache reads

### DIFF
--- a/src/lib/server/firebaseUtils.ts
+++ b/src/lib/server/firebaseUtils.ts
@@ -180,3 +180,23 @@ export const deletePath = async (path: string) =>
       else resolve();
     });
   });
+
+const cache = new Map<string, any>();
+/**
+ * Reads data from a firebase path and caches it for a specified duration.
+ * Improves best-case performance for data that can be safely cached.
+ * In a serverless environment, if the function is cold-started, the cache will be empty, but subsequent calls will be faster.
+ * @param path the firebase path of the data
+ * @param duration the duration in milliseconds to cache the data. Default is 60000 (1 minute).
+ * @returns the data from the path
+ */
+export const readPathWithCache = async <T>(path: string, duration: number = 60000): Promise<T | null> => {
+  if (cache.has(path)) return cache.get(path);
+
+  const data = await readPath(path);
+  cache.set(path, data);
+  setTimeout(() => {
+    cache.delete(path);
+  }, duration);
+  return data;
+};

--- a/src/routes/api/decks/preloaded/+server.ts
+++ b/src/routes/api/decks/preloaded/+server.ts
@@ -1,9 +1,9 @@
-import { getOrganizationDecks, getUserData, getUserOrganizations, readPath, weaklyAuthenticate } from '$lib/server/firebaseUtils';
+import { readPathWithCache } from '$lib/server/firebaseUtils';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET = (async (request) => {
-  const decks = (await readPath<Database.Decks.Preloaded>('/decks/preloaded')) || {};
+  const decks = (await readPathWithCache<Database.Decks.Preloaded>('/decks/preloaded')) || {};
   const deckArray = Object.entries(decks).map(([key, val]) => val);
   return json(deckArray);
 }) satisfies RequestHandler;

--- a/src/routes/api/playlists/library/+server.ts
+++ b/src/routes/api/playlists/library/+server.ts
@@ -1,11 +1,11 @@
-import { readPath } from '$lib/server/firebaseUtils';
+import { readPathWithCache } from '$lib/server/firebaseUtils';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { filterAttributes, transformPlaylistForClient } from '$lib/utils';
 
 export const GET = (async (request) => {
   const attributes = request.url.searchParams.get('attributes')?.split(',') ?? [];
-  const playlists = (await readPath<Database.Playlists.Library>('/playlists/library')) || {};
+  const playlists = (await readPathWithCache<Database.Playlists.Library>('/playlists/library')) || {};
   const playlistArray = Object.values(playlists).map((playlist) => ({
     ...playlist,
     words: transformPlaylistForClient(playlist) ?? [],

--- a/src/routes/api/playlists/preloaded/+server.ts
+++ b/src/routes/api/playlists/preloaded/+server.ts
@@ -1,10 +1,10 @@
-import { readPath } from '$lib/server/firebaseUtils';
+import { readPathWithCache } from '$lib/server/firebaseUtils';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { transformPlaylistForClient } from '$lib/utils';
 
 export const GET = (async (request) => {
-  const playlists = (await readPath<Database.Playlists.Preloaded>('/playlists/preloaded')) || {};
+  const playlists = (await readPathWithCache<Database.Playlists.Preloaded>('/playlists/preloaded')) || {};
   const playlistArray = Object.values(playlists).map((playlist) => ({
     ...playlist,
     words: transformPlaylistForClient(playlist) ?? [],


### PR DESCRIPTION
For resources that are common and rarely modified, we may as well keep them in memory for a bit and if the function stays warm, it will dramatically improve best-case performance. Only made the change on low-hanging fruit (preloaded/library resources) for now. 

Example of performance gains on `/playlists/preloaded` route (granted the result is empty because this was in preview):
![image](https://github.com/CSMA-Technology/blend-product-site/assets/10676387/4d1301ce-cce5-4b4b-9b43-cdc64cb2c0ca)
