### PR TITLE
fix(org-invite): fix redirect for new user

### DIFF
--- a/src/lib/server/firebaseUtils.ts
+++ b/src/lib/server/firebaseUtils.ts
@@ -3,7 +3,6 @@ import firebaseAdminCredential, { databaseURL } from '$lib/server/firebaseAdminC
 import { error, type Cookies, type RequestEvent, redirect } from '@sveltejs/kit';
 import type { ThenableReference } from 'firebase-admin/database';
 import type { DecodedIdToken, UserIdentifier, UserRecord } from 'firebase-admin/auth';
-import { user } from '$lib/firebase';
 if (!firebaseAdmin.apps.length) {
   firebaseAdmin.initializeApp({
     credential: firebaseAdmin.credential.cert(firebaseAdminCredential),
@@ -29,7 +28,7 @@ type CheckSessionAuthOptions = {
  */
 export const checkSessionAuth = async (cookies: Cookies, options: CheckSessionAuthOptions = {}) => {
   const { loginRedirect, authFunction } = options;
-  const successRedirect = loginRedirect ? `/login?successRedirect=${encodeURIComponent(loginRedirect)}` : '/login';
+  const successRedirect = loginRedirect ? `/login?successRedirect=${encodeURIComponent(loginRedirect.replace('?', '&'))}` : '/login';
   const sessionCookie = cookies.get('session');
   // If there is no cookie, they are not logged in
   if (!sessionCookie) throw redirect(302, successRedirect);


### PR DESCRIPTION
in `/organization/invite/[inviteId]/+page.server.ts`: 
![image](https://github.com/CSMA-Technology/blend-product-site/assets/6991957/6614759c-2198-4cb0-a825-e59102e37be3)

in `checkSessionAuth` the loginRedirect would get appended directly to the new param `successRedirect` resulting in a weird looking url - (obv this would be encoded)
`https://blendreading.com/login?successRedirect=/organization/invite/inviteId?action=acceptInvite` so the account page wasn't able to get the `action` parameter