### PR TITLE
refactor(forms): remove netlify prefix from subject

### DIFF
--- a/src/routes/help/feedback/+page.svelte
+++ b/src/routes/help/feedback/+page.svelte
@@ -20,7 +20,7 @@
     <p>Complete the form below to tell us about your experience with Blend and submit any ideas for new features!</p>
     <form name="feedback" method="post" action="/help/feedback/success" data-netlify="true">
       <input type="hidden" name="form-name" value="feedback" />
-      <input type="hidden" name="subject" value="Feedback Submission from blendreading.com" />
+      <input type="hidden" name="subject" data-remove-prefix value="Feedback Submission from blendreading.com" />
       <input type="hidden" name="uid" value={$user?.uid} />
       <input type="hidden" name="name" value={$user?.displayName} />
       <input type="hidden" name="email" value={$user?.email} />

--- a/src/routes/help/report-an-issue/+page.svelte
+++ b/src/routes/help/report-an-issue/+page.svelte
@@ -10,7 +10,7 @@
     <p>Thank you for your patience!</p>
     <form name="issue-report" action="/help/report-an-issue/success" method="POST" data-netlify="true">
       <input type="hidden" name="form-name" value="issue-report" />
-      <input type="hidden" name="subject" value="Issue Report from blendreading.com" />
+      <input type="hidden" name="subject" data-remove-prefix value="Issue Report from blendreading.com" />
       <p><label class="form-label">Email<input type="email" name="email" required /></label></p>
       <p><label class="form-label">Message<textarea name="message" required></textarea></label></p>
       <p><button class="btn" type="submit">Submit</button></p>

--- a/src/routes/organization/+page.svelte
+++ b/src/routes/organization/+page.svelte
@@ -123,7 +123,7 @@
         </div>
         <form name="organization-form" class="quote-form" action="/organization/request-a-quote" method="POST" data-netlify="true">
           <input type="hidden" name="form-name" value="organization-form" />
-          <input type="hidden" name="subject" value="Org License Quote Request from blendreading.com" />
+          <input type="hidden" name="subject" data-remove-prefix value="Org License Quote Request from blendreading.com" />
           <label>Name<input name="name" placeholder="Enter name" required /></label>
           <label>Email<input type="email" name="email" placeholder="Enter email" required /></label>
           <label>Organization Name<input name="orgName" placeholder="Enter organization name" required /></label>


### PR DESCRIPTION
I knew there had to be a way to do this and found it here
https://docs.netlify.com/forms/notifications/#remove-netlify-prefix-from-your-email-subject-line