### PR TITLE
feat(caching): add cache headers to user decks and playlists

### DIFF
--- a/src/routes/api/playlists/user/+server.ts
+++ b/src/routes/api/playlists/user/+server.ts
@@ -8,6 +8,12 @@ export const GET = (async (event) => {
   const userPlaylists = (await readPath<Database.Playlists.User>(`/playlists/user/${uid}`)) || {};
   const userPlaylistsArray = Object.values(userPlaylists).map((playlist) => playlist);
   const organizationIds = await getUserOrganizations(uid);
+
+  const headers = {
+    'Cache-Control': event.request.headers.get('x-cache-nonce') ? 'private, max-age=300, must-revalidate' : 'private, no-cache',
+    Vary: 'x-cache-nonce',
+  };
+
   const organizationPlaylistsArray = (
     await Promise.all(
       organizationIds.map(async (orgId) => {
@@ -28,7 +34,7 @@ export const GET = (async (event) => {
     ...playlist,
     words: transformPlaylistWordsForClient(playlist.words ?? []),
   }));
-  return json(modifiedPlaylists);
+  return json(modifiedPlaylists, { headers });
 }) satisfies RequestHandler;
 
 export const OPTIONS = (() => {


### PR DESCRIPTION
This will allow short-term caching of the `/api/[decks|playlists]/user` routes.

The cache duration is only 5 minutes, it is just meant to make the experience of navigating the home screens smoother. 

Cache invalidation is a challenge in the case of user making edits or logging out. For that reason, I have included a new custom header, `x-cache-nonce` in the `Vary` header, which tells the cache to consider that header as part of the cache key. The Godot app will then be responsible for changing that nonce when appropriate. If `x-cache-nonce` is not present, the resources will not cache, so this is backwards compatible with old app versions and can be released right away. 