### PR TITLE
fix(account): fixed a bug where a customer without a Stripe account was always shown as basic

### DIFF
--- a/src/routes/account/+page.server.ts
+++ b/src/routes/account/+page.server.ts
@@ -7,6 +7,7 @@ import {
   createStripeSession,
   isCustomerSubscribedToBlendPro,
   isOrganizationMember,
+  isSubscribedToBlendPro,
 } from '$lib/server/subscriptionUtils';
 import { auth, checkSessionAuth, getUserData, getUserOrganizations, isUserGlobalAdmin, readPath, writePath } from '$lib/server/firebaseUtils';
 
@@ -63,22 +64,13 @@ export const load = (async ({ url, cookies }) => {
     }
   }
 
-  if (!customer || customer.deleted) {
-    return {
-      isSubscribedToBlendPro: false,
-      hasOrganizationMembership: organizations.length > 0,
-      subscriptionPeriodEnd: 0,
-      subscriptionPendingCancellation: false,
-      organizations: JSON.stringify(organizations),
-    };
-  }
-  const subscription = getBlendProSubscription(customer);
+  const subscription = customer && !customer.deleted ? getBlendProSubscription(customer) : null;
 
   return {
-    isSubscribedToBlendPro: !!subscription,
+    isSubscribedToBlendPro: await isSubscribedToBlendPro(uid),
     hasOrganizationMembership: organizations.length > 0,
     subscriptionPeriodEnd: subscription?.current_period_end ?? 0,
-    subscriptionPendingCancellation: subscription?.cancel_at_period_end,
+    subscriptionPendingCancellation: subscription?.cancel_at_period_end ?? false,
     organizations: JSON.stringify(organizations),
   };
 }) satisfies PageServerLoad;

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -136,7 +136,7 @@
               <input type="hidden" name="uid" value={$user?.uid} />
               <button id="checkout-and-portal-button" type="submit" class="btn">Manage Subscription</button>
             </form>
-          {:else}
+          {:else if subscriptionPeriodEnd}
             <p>
               Your next billing period starts on {new Date(subscriptionPeriodEnd * 1000).toLocaleDateString()}
             </p>
@@ -144,6 +144,8 @@
               <input type="hidden" name="uid" value={$user?.uid} />
               <button id="checkout-and-portal-button" type="submit" class="btn">Manage Subscription</button>
             </form>
+          {:else}
+            <p>Your subscription is active.</p>
           {/if}
         </div>
       {:else if hasOrganizationMembership}


### PR DESCRIPTION
In the emulator there is a customer that is pro in the database, but does not have a Stripe account, so the account page was showing that they were basic, when they were in fact pro (the API worked fine). This may happen to someone who is an org member but not a customer in Stripe. In this case now I just added a little placeholder that says "Your subscription is active" in place of the option to either upgrade to pro or cancel
![image](https://github.com/user-attachments/assets/a95112ab-f3c6-403e-86c9-9d5c3e52fcde)
