### PR TITLE
feat(checkout): added the option to skip trial via query param

### DIFF
--- a/src/lib/server/subscriptionUtils.ts
+++ b/src/lib/server/subscriptionUtils.ts
@@ -129,7 +129,7 @@ export const createStripeSession = async (
   email: string,
   name: string,
   origin: string,
-  options?: { successUrl?: string; subscriptionType?: 'yearly' | 'monthly'; promoCode?: string },
+  options?: { successUrl?: string; subscriptionType?: 'yearly' | 'monthly'; promoCode?: string; skipTrial?: boolean },
 ) => {
   const priceCode = options?.subscriptionType === 'yearly' ? STRIPE_BLEND_PRO_ANNUAL_PRICE_CODE : STRIPE_BLEND_PRO_PRICE_CODE;
   console.log(`Fetching Stripe customer ID for user ${uid}`);
@@ -161,7 +161,7 @@ export const createStripeSession = async (
   }
 
   const hadBlendProBefore = hasCustomerSubscribedBefore(allSubscriptions, STRIPE_BLEND_PRO_PRODUCT_CODE);
-  if (!hadBlendProBefore) {
+  if (!options?.skipTrial && !hadBlendProBefore) {
     subscriptionData = {
       trial_period_days: 7,
     };

--- a/src/routes/account/+page.server.ts
+++ b/src/routes/account/+page.server.ts
@@ -56,6 +56,7 @@ export const load = (async ({ url, cookies }) => {
           successUrl,
           subscriptionType: newParams.get('subscriptionType') === 'yearly' ? 'yearly' : 'monthly',
           promoCode: newParams.get('promoCode') ?? undefined,
+          skipTrial: newParams.has('skipTrial') ?? false,
         });
         throw redirect(303, stripeSession.url!);
       }


### PR DESCRIPTION
One note: The presence of the param is all that is required, so it can be `&skipTrial=1`, `&skipTrial=true`, `&skipTrial=false`, or no value, `&skipTrial`. All the same.

An example URL (local) would be:
`http://localhost:5173/account?action=upgrade&subscriptionType=yearly&promoCode=IDA2024&skipTrial`