### PR TITLE
feat(partners): add partner metadata on checkout

### DIFF
--- a/src/lib/server/subscriptionUtils.ts
+++ b/src/lib/server/subscriptionUtils.ts
@@ -198,6 +198,12 @@ export const createStripeSession = async (
     };
   }
 
+  if (options?.partnerId) {
+    subscriptionData.metadata = {
+      partnerId: options.partnerId,
+    };
+  }
+
   console.log(`Customer is ${subscriptionData.trial_period_days ? '' : 'not '}eligible for a free trial.`);
   console.log('Creating Stripe session');
 

--- a/src/routes/admin/+layout.server.ts
+++ b/src/routes/admin/+layout.server.ts
@@ -1,0 +1,7 @@
+import { checkSessionAuth, isUserGlobalAdmin } from '$lib/server/firebaseUtils';
+
+export const load = async ({ cookies }) => {
+  await checkSessionAuth(cookies, {
+    authFunction: async ({ uid }) => await isUserGlobalAdmin(uid),
+  });
+};

--- a/src/routes/admin/partners/partnerCard.svelte
+++ b/src/routes/admin/partners/partnerCard.svelte
@@ -61,7 +61,7 @@
             <dt>UID:</dt>
             <dd class="col-span-2">{uid}</dd>
             <dt>Checkout Time:</dt>
-            <dd class="col-span-2">{new Date(promoCodeRedemption.checkoutTimestamp).toLocaleString()}</dd>
+            <dd class="col-span-2">{new Date(promoCodeRedemption.checkoutTimestamp * 1000).toLocaleString()}</dd>
             <dt>Stripe Subscription</dt>
             <dd class="col-span-2">
               {promoCodeRedemption.subscriptionId}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,9 +8,7 @@ const config = {
   preprocess: preprocess(),
 
   kit: {
-    adapter: adapter({
-      split: true,
-    }),
+    adapter: adapter(),
   },
 };
 


### PR DESCRIPTION
This is deployed on test and I tested with a few new subs. 

I also added server-side auth checks to the admin pages, and finally tried collapsing all the page functions into one. At least on the test page, everything is feeling much snappier with that. Function should stay warm most of the time, which should help alot. Downside is logs will be a mess, we will need to add some more metadata to them. 