### PR TITLE
feat(login): added option to show the user a message on login redirect

### DIFF
--- a/src/lib/components/AuthCheck.svelte
+++ b/src/lib/components/AuthCheck.svelte
@@ -24,8 +24,13 @@
    */
   export let defaultRedirect: string | null | ((user: User) => string) = null;
 
+  /**
+   * The message to display to the user when they are redirected to the login page. Shpuld be an ID of a message in $lib/messages.ts.
+   */
+  export let messageId: string = 'loginRedirect';
+
   $: {
-    if (!$user && !willAttemptLogin()) goto(`/login?successRedirect=${encodeURIComponent(loginRedirect)}`);
+    if (!$user && !willAttemptLogin()) goto(`/login?successRedirect=${encodeURIComponent(loginRedirect)}&message=${messageId}`);
     else if ($user && defaultRedirect) goto(typeof defaultRedirect === 'function' ? defaultRedirect($user) : defaultRedirect);
   }
 </script>

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,0 +1,8 @@
+// This is a list of messages to be displayed throughout the app in various toasts, alerts, etc.
+// Putting them here for now to import them and keep things like query params simple (just the ID). Also should make internationalization easier.
+
+export default {
+  loginRedirect: 'You must be logged in to view this page.',
+  feedbackRedirect: 'You must be logged in to submit feedback.',
+  signedOut: 'You have been signed out.',
+} as Record<string, string>;

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -29,7 +29,7 @@
   const onSignOutCLicked = async () => {
     disableSignOut = true;
     await signOut();
-    goto('/login');
+    goto('/login?message=signedOut');
   };
 
   const leaveOrganization = async (orgId: string) => {

--- a/src/routes/help/feedback/+page.svelte
+++ b/src/routes/help/feedback/+page.svelte
@@ -10,7 +10,7 @@
 </svelte:head>
 
 {#if browser}
-  <AuthCheck />
+  <AuthCheck messageId="feedbackRedirect" />
 {/if}
 
 <div class="content">

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -8,6 +8,8 @@
   import { goto } from '$app/navigation';
   import { isEmbeddedBrowser } from '$lib/utils';
   import Alert from '$lib/components/Alert.svelte';
+  import { fly } from 'svelte/transition';
+  import messages from '$lib/messages';
 
   signOut(); // Make sure we're not logged in when we get here
 
@@ -19,6 +21,7 @@
   const searchParams = new URLSearchParams(decodeURIComponent($page.url.search));
   const redirectParam = searchParams.get('successRedirect') || '/';
   const actionParam = searchParams.get('action') || '';
+  const messageParam = searchParams.get('message') || '';
   const allOtherParams = Array.from(searchParams.entries())
     .filter(([key]) => key !== 'successRedirect' && key !== 'action')
     .map(([key, value]) => `${key}=${value}`)
@@ -27,6 +30,10 @@
   type RedirectBuilderFunc = (user: User, token?: string) => string;
   let redirectBuilder: RedirectBuilderFunc;
   let isAppRedirect = false;
+  let isMounted = false;
+
+  let message = messages[messageParam];
+
   switch (redirectParam) {
     case 'account':
     case '/':
@@ -62,6 +69,7 @@
       redirectBuilder = () => `${decodeURIComponent(redirectParam)}${allOtherParams ? `?${allOtherParams}` : ''}`;
   }
   onMount(() => {
+    isMounted = true;
     ui.start('#firebaseui-auth-container', {
       callbacks: {
         signInSuccessWithAuthResult(authResult, redirectUrl) {
@@ -130,6 +138,14 @@
   <title>Login - Blend</title>
 </svelte:head>
 
+{#if message && isMounted}
+  <div
+    in:fly|global={{ y: -50, duration: 750 }}
+    class="relative mx-6 -mb-8 mt-4 max-w-2xl rounded-xl border-2 border-black bg-white px-6 py-4 text-center shadow
+      sm:mx-auto">
+    {message}
+  </div>
+{/if}
 <div class="content">
   {#if !awaitingRedirect}
     <h1>Log in or Create Account</h1>


### PR DESCRIPTION
Only works for client-side redirects right now, but that is sufficient for the feedback form. 

Just sprinkled a few in:
The default:
![image](https://github.com/user-attachments/assets/ab3d6e07-7d04-43bb-bec3-c3326893467b)

Feedback form:
![image](https://github.com/user-attachments/assets/6c90c942-730a-4f8b-a5b5-537ed31356a6)

When you sign out from the account page:
![image](https://github.com/user-attachments/assets/128b82ed-0512-46b6-8937-ee5f9cf9db37)
