### PR TITLE
feat(feedback): allow feedback form items to be populated from query params

### DIFF
--- a/src/routes/help/feedback/+page.svelte
+++ b/src/routes/help/feedback/+page.svelte
@@ -3,11 +3,15 @@
   import AuthCheck from '$lib/components/AuthCheck.svelte';
   import { user } from '$lib/firebase';
   import { page } from '$app/stores';
-  import { onMount } from 'svelte';
+  import { beforeUpdate } from 'svelte';
 
-  const originalSearchParams = $page.url.searchParams;
-  onMount(() => {
+  let originalSearchParams = new URLSearchParams();
+  let didCleanParams = false;
+  beforeUpdate(() => {
+    if (didCleanParams) return;
+    originalSearchParams = new URLSearchParams($page.url.search);
     window.history.replaceState({}, '', '/help/feedback');
+    didCleanParams = true;
   });
 </script>
 
@@ -18,7 +22,7 @@
 {#if browser}
   <AuthCheck
     messageId="feedbackRedirect"
-    loginRedirect={originalSearchParams.size ? `${$page.url.pathname}?${originalSearchParams.toString()}` : $page.url.pathname} />
+    loginRedirect={originalSearchParams.size ? `${$page.url.pathname}?${encodeURIComponent(originalSearchParams.toString())}` : $page.url.pathname} />
 {/if}
 
 <div class="content">

--- a/src/routes/help/feedback/+page.svelte
+++ b/src/routes/help/feedback/+page.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
   import { browser } from '$app/environment';
-  import { enhance } from '$app/forms';
   import AuthCheck from '$lib/components/AuthCheck.svelte';
   import { user } from '$lib/firebase';
+  import { page } from '$app/stores';
+  import { onMount } from 'svelte';
+
+  const originalSearchParams = $page.url.searchParams;
+  onMount(() => {
+    window.history.replaceState({}, '', '/help/feedback');
+  });
 </script>
 
 <svelte:head>
@@ -10,12 +16,14 @@
 </svelte:head>
 
 {#if browser}
-  <AuthCheck messageId="feedbackRedirect" />
+  <AuthCheck
+    messageId="feedbackRedirect"
+    loginRedirect={originalSearchParams.size ? `${$page.url.pathname}?${originalSearchParams.toString()}` : $page.url.pathname} />
 {/if}
 
 <div class="content">
-  <h1>We want your feedback!</h1>
-  <div class="form-details">
+  <h1 class="my-4">We want your feedback!</h1>
+  <div class="flex flex-col items-center rounded-xl bg-[rgba(255,255,255,0.15)] p-4 sm:p-10">
     <p>We'd love to hear what you think about our app.</p>
     <p>Complete the form below to tell us about your experience with Blend and submit any ideas for new features!</p>
     <form name="feedback" method="post" action="/help/feedback/success" data-netlify="true">
@@ -24,11 +32,37 @@
       <input type="hidden" name="uid" value={$user?.uid} />
       <input type="hidden" name="name" value={$user?.displayName} />
       <input type="hidden" name="email" value={$user?.email} />
-      <p><label class="form-label">What do you like about using Blend?<textarea name="positiveFeedback" required></textarea></label></p>
-      <p><label class="form-label">What could make your experience better?<textarea name="improvementFeedback" required></textarea></label></p>
-      <p><label class="form-label">What new features would you like to see?<textarea name="featureRequests" required></textarea></label></p>
+      <fieldset class="radio mb-1">
+        <legend class="form-label !mb-0">Would you recommend Blend to a fellow teacher?</legend>
+        <div class="mx-auto my-2 flex gap-6">
+          <label>
+            <input type="radio" name="recommendation" value="yes" checked={originalSearchParams.get('recommendation') === 'yes'} />
+            Yes
+          </label>
+          <label>
+            <input type="radio" name="recommendation" value="no" checked={originalSearchParams.get('recommendation') === 'no'} />
+            No
+          </label>
+        </div>
+      </fieldset>
+      <p>
+        <label class="form-label"
+          >What do you like about using Blend?<textarea name="positiveFeedback">{originalSearchParams.get('positiveFeedback') ?? ''}</textarea
+          ></label>
+      </p>
+      <p>
+        <label class="form-label"
+          >What could make your experience better?<textarea name="improvementFeedback"
+            >{originalSearchParams.get('improvementFeedback') ?? ''}</textarea
+          ></label>
+      </p>
+      <p>
+        <label class="form-label"
+          >What new features would you like to see?<textarea name="featureRequests">{originalSearchParams.get('featureRequests') ?? ''}</textarea
+          ></label>
+      </p>
       <fieldset class="radio">
-        <legend class="form-label"><p>Can we publish your responses on our website?</p></legend>
+        <legend class="form-label !mb-0"><p>Can we publish your responses on our website?</p></legend>
         <label>
           <input type="radio" name="publishable" value="yes" checked />
           Yes
@@ -44,7 +78,7 @@
           </label>
         </div>
       </fieldset>
-      <p><button class="btn" type="submit">Submit</button></p>
+      <button class="btn !mx-auto" type="submit">Submit</button>
     </form>
   </div>
 </div>
@@ -58,14 +92,6 @@
 
   p {
     margin: 0;
-  }
-  .form-details {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 2.5rem;
-    background: rgba(255, 255, 255, 0.15);
-    border-radius: 10px;
   }
   .btn {
     margin: 1rem 0;

--- a/src/routes/help/feedback/+page.ts
+++ b/src/routes/help/feedback/+page.ts
@@ -1,2 +1,1 @@
-export const prerender = true;
 export const ssr = true;

--- a/src/routes/help/feedback/+page.ts
+++ b/src/routes/help/feedback/+page.ts
@@ -1,1 +1,2 @@
+export const prerender = true;
 export const ssr = true;

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -23,7 +23,7 @@
   const actionParam = searchParams.get('action') || '';
   const messageParam = searchParams.get('message') || '';
   const allOtherParams = Array.from(searchParams.entries())
-    .filter(([key]) => key !== 'successRedirect' && key !== 'action')
+    .filter(([key]) => !['successRedirect', 'action', 'message'].includes(key))
     .map(([key, value]) => `${key}=${value}`)
     .join('&');
 


### PR DESCRIPTION
https://www.notion.so/Blend-MVP-13-14b79d5e454680b9b6b4d18fa72c7f94?p=16d79d5e4546800bbc23d664e3ac529a&pm=s

Minimally changed CSS to move towards Tailwind and make it a little nicer on small screens. 

Also found a bug on the login page, the `message` param was being included in the params that gets passed along

Example URL with all fields populated:
`http://localhost:5173/help/feedback?recommendation=yes&positiveFeedback=sucks&improvementFeedback=really%20sucks&featureRequests=less%20suck`